### PR TITLE
feat: remove rebase

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,6 @@ runs:
         # If PR Already exist, rebase to main branch and switch to ${{ steps.get-pr-info.outputs.branch }}
         git fetch
         git checkout "${{ steps.get-pr-info.outputs.branch }}"
-        git rebase --strategy-option ours $(gh pr view ${{ steps.get-pr-info.outputs.id }} --json baseRefName --jq '.[]') $(gh pr view ${{ steps.get-pr-info.outputs.id }} --json headRefName --jq '.[]') 
     - name: Run script
       shell: bash
       run: |


### PR DESCRIPTION
Remove automatic rebase because of unneeded when PR can do it with a simple button.
Making automatic rebase can make the PR fail when not doing it just let it go.